### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/polyviz/choro.py
+++ b/polyviz/choro.py
@@ -18,6 +18,9 @@ try:
     from bw2data.backends import Activity as BW25Activity
 except ImportError:
     BW25Activity = None
+    
+valid_types = tuple(filter(None, (PeeweeActivity, BW25Activity)))
+
 
 def choro(
     activity: Union[PeeweeActivity, BW25Activity],
@@ -45,7 +48,7 @@ def choro(
 
     assert isinstance(method, tuple), "`method` should be a tuple."
     assert isinstance(
-        activity, (PeeweeActivity, BW25Activity)
+        activity, valid_types
     ), "`activity` should be a brightway2 activity."
 
     # fetch unit of method

--- a/polyviz/treemap.py
+++ b/polyviz/treemap.py
@@ -19,6 +19,9 @@ try:
 except ImportError:
     BW25Activity = None
 
+valid_types = tuple(filter(None, (PeeweeActivity, BW25Activity)))
+
+
 def treemap(
     activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
@@ -45,7 +48,7 @@ def treemap(
 
     assert isinstance(method, tuple), "`method` should be a tuple."
     assert isinstance(
-        activity, (PeeweeActivity, BW25Activity)
+        activity, valid_types
     ), "`activity` should be a brightway2 activity."
 
     # fetch unit of method

--- a/polyviz/utils.py
+++ b/polyviz/utils.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     BW25Activity = None
 
+valid_types = tuple(filter(None, (PeeweeActivity, BW25Activity)))
+
 
 def calculate_supply_chain(
     activity: Union[PeeweeActivity, BW25Activity],
@@ -41,7 +43,7 @@ def calculate_supply_chain(
     """
 
     assert isinstance(
-        activity, (PeeweeActivity, BW25Activity)
+        activity, valid_types
     ), "`activity` should be a brightway2 activity."
 
     amount = -1 if identify_waste_process(activity) else 1
@@ -76,7 +78,7 @@ def calculate_lcia_score(
     :return: LCIA score, C matrix, and reverse dictionary
     """
     assert isinstance(
-        activity, (PeeweeActivity, BW25Activity)
+        activity, valid_types
     ), "`activity` should be a brightway2 activity."
 
     print("Calculating LCIA score...")
@@ -117,7 +119,7 @@ def identify_waste_process(activity: Union[PeeweeActivity, BW25Activity]) -> boo
 
 
 def get_geo_distribution_of_impacts_for_choro_graph(
-    activity: (PeeweeActivity, BW25Activity),
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     cutoff: float = 0.0001,
 ) -> pd.DataFrame:

--- a/polyviz/violin.py
+++ b/polyviz/violin.py
@@ -20,6 +20,9 @@ try:
 except ImportError:
     BW25Activity = None
 
+valid_types = tuple(filter(None, (PeeweeActivity, BW25Activity)))
+
+
 def violin(
     activities: list,
     method: tuple,
@@ -43,7 +46,7 @@ def violin(
 
     for act in activities:
         assert isinstance(
-            act, Union[PeeweeActivity, BW25Activity]
+            act, valid_types
         ), "`activity` should be a brightway2 activity."
 
     def make_name(activities):


### PR DESCRIPTION
The activity type checks didn't work for Python 3.12, so I did some more generalisation. I checked for Python 3.9, 3.11 and 3.12 and it looks good now.

Also, I forgot to change the violin plot type check in the earlier PR, this is now also fixed.